### PR TITLE
Reduce the memory usage of go-ipfs

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -10,7 +10,7 @@ GRAPH
   build-essential (8.1.1)
     mingw (>= 1.1)
     seven_zip (>= 0.0.0)
-  ipfs (0.1.0)
+  ipfs (0.1.3)
     ark (>= 0.0.0)
   mingw (2.1.0)
     seven_zip (>= 0.0.0)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,3 +83,26 @@ end
 ipfs_config 'Swarm.AddrFilters' do
   value node['ipfs']['config']['swarm']['addr_filter']
 end
+
+# Do not keep track of bandwidth metrics. Disabling bandwidth metrics can
+# lead to a slight performance improvement, as well as a reduction in memory
+# usage.
+ipfs_config 'Swarm.DisableBandwidthMetrics' do
+  value true
+end
+
+# Disable the p2p-circuit relay transport
+ipfs_config 'Swarm.DisableRelay' do
+  value true
+end
+
+# Number of connections that, when exceeded, will trigger a connection GC
+# operation
+ipfs_config 'Swarm.ConnMgr.HighWater' do
+  value 10
+end
+
+# Minimum number of connections to maintain
+ipfs_config 'Swarm.ConnMgr.LowWater' do
+  value 1
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -99,10 +99,10 @@ end
 # Number of connections that, when exceeded, will trigger a connection GC
 # operation
 ipfs_config 'Swarm.ConnMgr.HighWater' do
-  value 10
+  value '10'
 end
 
 # Minimum number of connections to maintain
 ipfs_config 'Swarm.ConnMgr.LowWater' do
-  value 1
+  value '1'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -99,10 +99,10 @@ end
 # Number of connections that, when exceeded, will trigger a connection GC
 # operation
 ipfs_config 'Swarm.ConnMgr.HighWater' do
-  value '10'
+  value 10
 end
 
 # Minimum number of connections to maintain
 ipfs_config 'Swarm.ConnMgr.LowWater' do
-  value '1'
+  value 1
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'mixlib/shellout'
 
 property :key, String, name_property: true
-property :value, [String, Hash, Array, TrueClass, FalseClass], required: true
+property :value, [String, Hash, Array, TrueClass, FalseClass, Integer], required: true
 
 action :create do
   include_recipe 'ipfs'

--- a/templates/default/ipfs.systemd.service.erb
+++ b/templates/default/ipfs.systemd.service.erb
@@ -2,12 +2,14 @@
 Description=Start ipfs
 
 [Service]
-ExecStart=/usr/local/bin/ipfs daemon --migrate
+ExecStart=/usr/local/bin/ipfs daemon --migrate --routing=dhtclient
 User=ipfs
 Group=ipfs
 Restart=always
 # Raise the ulimit (max number of open files)
 LimitNOFILE=64000
+# Limit the memory usage to 256MB
+MemoryMax=256M
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Lower the number of connections, change the routing mode to dhtclient, and disable bandwidth metrics. This is hardcoded for now