### PR TITLE
Add the checksums for the cluster packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ env:
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(chef shell-init bash)"
-  - chef --version
+  - CHEF_LICENSE=accept-no-persist chef --version
   - cookstyle --version
   - foodcritic --version
 
-script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml CHEF_VERSION=13.10.4 kitchen verify ${INSTANCE}
+script: CHEF_LICENSE=accept-no-persist KITCHEN_LOCAL_YAML=.kitchen.dokken.yml CHEF_VERSION=13.10.4 kitchen verify ${INSTANCE}
 
 matrix:
   include:
     - script:
-      - chef exec delivery local all
+      - CHEF_LICENSE=accept-no-persist chef exec delivery local all
       env: UNIT_AND_LINT=1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,5 @@ node.default['ipfs']['checksum'] = '1bb1050ebe74f9042ac721eb1b71f92e1b0e78e54c59
 node.default['ipfs']['config']['swarm']['addr_filter'] = ['/ip4/10.0.0.0/ipcidr/8', '/ip4/100.64.0.0/ipcidr/10', '/ip4/169.254.0.0/ipcidr/16', '/ip4/172.16.0.0/ipcidr/12', '/ip4/192.0.0.0/ipcidr/24', '/ip4/192.0.0.0/ipcidr/29', '/ip4/192.0.0.8/ipcidr/32', '/ip4/192.0.0.170/ipcidr/32', '/ip4/192.0.0.171/ipcidr/32', '/ip4/192.0.2.0/ipcidr/24', '/ip4/192.168.0.0/ipcidr/16', '/ip4/198.18.0.0/ipcidr/15', '/ip4/198.51.100.0/ipcidr/24', '/ip4/203.0.113.0/ipcidr/24', '/ip4/240.0.0.0/ipcidr/4']
 
 node.default['ipfs']['cluster']['version'] = '0.4.0'
+node.default['ipfs']['cluster']['service']['checksum'] = 'a168e9d3544f53f3d734098533d606b88417f6319bc8f83b1af7ef1328ed246a'
+node.default['ipfs']['cluster']['ctl']['checksum'] = 'c82ba76b21a6fc42c8c635962a356c51fe6d4d0fbac2a77bfdd159cbe6a56f49'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'mail@kosmos.org'
 license          'MIT'
 description      'Installs/Configures ipfs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.3'
+version          '0.2.0'
 
 supports %w(ubuntu debian)
 

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -30,11 +30,13 @@ version = node['ipfs']['cluster']['version']
 
 ark 'ipfs-cluster-service' do
   url "https://dist.ipfs.io/ipfs-cluster-service/v#{version}/ipfs-cluster-service_v#{version}_linux-amd64.tar.gz"
+  checksum node['ipfs']['cluster']['service']['checksum']
   has_binaries ['ipfs-cluster-service']
 end
 
 ark 'ipfs-cluster-ctl' do
   url "https://dist.ipfs.io/ipfs-cluster-ctl/v#{version}/ipfs-cluster-ctl_v#{version}_linux-amd64.tar.gz"
+  checksum node['ipfs']['cluster']['ctl']['checksum']
   has_binaries ['ipfs-cluster-ctl']
 end
 


### PR DESCRIPTION
It prevents Chef from trying to download the packages again if the files are already present with the correct checksum

Ready to merge, confirmed to work on Andromeda