### PR TITLE
Update go-ipfs to 0.4.22

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
-node.default['ipfs']['version'] = '0.4.21'
-node.default['ipfs']['checksum'] = 'a7ec5ddc4d52f818cbf3853a80f7ec17f9fde9128f039485dbe1889cf673d562'
+node.default['ipfs']['version'] = '0.4.22'
+node.default['ipfs']['checksum'] = '43431bbef105b1c8d0679350d6f496b934d005df28c13280a67f0c88054976aa'
 
 node.default['ipfs']['ulimit'] = 64000
 node.default['ipfs']['memory_max'] = '512M'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'mail@kosmos.org'
 license          'MIT'
 description      'Installs/Configures ipfs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.4.1'
 
 supports %w(ubuntu debian)
 


### PR DESCRIPTION
https://blog.ipfs.io/054-go-ipfs-0.4.22

Closes #11