### PR TITLE
Fix the specs

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -13,6 +13,7 @@ provisioner:
 
 verifier:
   name: inspec
+  chef_license: accept
 
 platforms:
   - name: ubuntu-18.04

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -15,10 +15,6 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-16.04
-    driver:
-      image: dokken/ubuntu-16.04
-      pid_one_command: /bin/systemd
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -29,8 +29,3 @@ suites:
     run_list:
       - recipe[ipfs::default]
     attributes:
-  - name: cluster
-    run_list:
-      - recipe[ipfs::cluster]
-      - recipe[ipfs::cluster_service]
-    attributes:

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -13,6 +13,7 @@ provisioner:
 
 verifier:
   name: inspec
+  root_path: '/opt/verifier' # Needed for the specs to be detected in Docker
   chef_license: accept
 
 platforms:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,8 +14,3 @@ suites:
     run_list:
       - recipe[ipfs::default]
     attributes:
-  - name: cluster
-    run_list:
-      - recipe[ipfs::cluster]
-      - recipe[ipfs::cluster_service]
-    attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,9 @@ platforms:
   - name: ubuntu-18.04
   - name: debian-9
 
+verifier:
+  chef_license: accept
+
 suites:
   - name: default
     run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,6 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-16.04
   - name: ubuntu-18.04
   - name: debian-9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - cookstyle --version
   - foodcritic --version
 
-script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen test ${INSTANCE}
+script: CHEF_LICENSE=accept-no-persist KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen test ${INSTANCE}
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - cookstyle --version
   - foodcritic --version
 
-script: CHEF_LICENSE=accept-no-persist KITCHEN_LOCAL_YAML=.kitchen.dokken.yml CHEF_VERSION=13.10.4 kitchen verify ${INSTANCE}
+script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen test ${INSTANCE}
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ services: docker
 env:
   matrix:
   - INSTANCE=default-debian-9
-  - INSTANCE=default-ubuntu-1604
   - INSTANCE=default-ubuntu-1804
 
 before_script:

--- a/test/integration/default/serverspec/ipfs_spec.rb
+++ b/test/integration/default/serverspec/ipfs_spec.rb
@@ -45,10 +45,7 @@ describe 'IPFS' do
 
   {
     'Swarm.AddrFilters' => addr_filters.rstrip,
-    'Swarm.DisableBandwidthMetrics' => true,
-    'Swarm.DisableRelay' => true,
-    'Swarm.ConnMgr.HighWater' => 10,
-    'Swarm.ConnMgr.LowWater' => 1,
+    'Gateway.Writable' => true
   }.each do |k, v|
     describe command("IPFS_PATH=/home/ipfs/.ipfs ipfs config '#{k}'") do
       let(:sudo_options) { '-u ipfs -i' }

--- a/test/integration/default/serverspec/ipfs_spec.rb
+++ b/test/integration/default/serverspec/ipfs_spec.rb
@@ -45,7 +45,7 @@ describe 'IPFS' do
 
   {
     'Swarm.AddrFilters' => addr_filters.rstrip,
-    'Gateway.Writable' => true
+    'Gateway.Writable' => true,
   }.each do |k, v|
     describe command("IPFS_PATH=/home/ipfs/.ipfs ipfs config '#{k}'") do
       let(:sudo_options) { '-u ipfs -i' }


### PR DESCRIPTION
* Fix the checks for the default config in the integration specs
* Do not run specs on Ubuntu 16.04
* Remove the deleted cluster specs from the kitchen config files
* Accept the Chef license as part of the config files
* Fix the specs not being seen on Travis 

<strike>Ready to merge when CI is green</strike>

Update: specs are green, ready to merge