### PR TITLE
Restart the service on update

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -10,7 +10,7 @@ GRAPH
   build-essential (8.1.1)
     mingw (>= 1.1)
     seven_zip (>= 0.0.0)
-  ipfs (0.4.0)
+  ipfs (0.4.2)
     ark (>= 0.0.0)
   mingw (2.1.0)
     seven_zip (>= 0.0.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'mail@kosmos.org'
 license          'MIT'
 description      'Installs/Configures ipfs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.1'
+version          '0.4.2'
 
 supports %w(ubuntu debian)
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,7 @@ ark 'ipfs' do
   url "https://dist.ipfs.io/go-ipfs/v#{version}/go-ipfs_v#{version}_linux-amd64.tar.gz"
   checksum node['ipfs']['checksum']
   has_binaries ['ipfs']
+  notifies :restart, 'service[ipfs]', :delayed
 end
 
 execute 'ipfs init --empty-repo' do


### PR DESCRIPTION
A restart notification on the service was missing on the ark resource that takes care of downloading and installing/updating go-ipfs

Fixes #14